### PR TITLE
If there is no footer view, bars won't be added to the chart.

### DIFF
--- a/Classes/JBBarChartView.m
+++ b/Classes/JBBarChartView.m
@@ -147,7 +147,14 @@ static UIColor *kJBBarChartViewDefaultBarColor = nil;
             barView.layer.shadowRadius = 1.0;
             
             [mutableBarViews addObject:barView];
-            [self insertSubview:barView belowSubview:self.footerView];
+			if (self.footerView)
+			{
+				[self insertSubview:barView belowSubview:self.footerView];
+			}
+			else
+			{
+				[self addSubview:barView];
+			}
             xOffset += ([self barWidth] + self.barPadding);
             index++;
         }


### PR DESCRIPTION
This fixes a pretty serious bug. Turns out that insertSubview:belowSubview: fails when the second subview is nil.
