### PR TITLE
Add delegate method barChartView:colorForBarViewAtIndex: to JBBarChartViewDataSource

### DIFF
--- a/Classes/JBBarChartView.h
+++ b/Classes/JBBarChartView.h
@@ -103,6 +103,19 @@
 - (UIView *)barChartView:(JBBarChartView *)barChartView barViewAtIndex:(NSUInteger)index;
 
 /**
+ *  The color for bar at a particular index.
+ *  If you already implement barChartView:barViewAtIndex: delegate - this method has no effect.
+ *
+ *  Default: if none specified - calls barChartView:barViewAtIndex:.
+ *
+ *  @param barChartView The bar chart object requesting this information.
+ *  @param index        The 0-based index of a given bar (left to right, x-axis).
+ *
+ *  @return The color to be used to shade a bar in the chart.
+ */
+- (UIColor *)barChartView:(JBBarChartView *)barChartView colorForBarViewAtIndex:(NSUInteger)index;
+
+/**
  *  The selection color to be overlayed on a bar during touch events. 
  *  The color is automically faded to transparent (vertically). The property showsVerticalSelection
  *  must be YES for the color to apply.

--- a/Classes/JBBarChartView.m
+++ b/Classes/JBBarChartView.m
@@ -181,8 +181,21 @@ static UIColor *kJBBarChartViewDefaultBarColor = nil;
             else
             {
                 barView = [[UIView alloc] init];
-                barView.backgroundColor = kJBBarChartViewDefaultBarColor;
+                UIColor *backgroundColor = nil;
+
+                if ([self.dataSource respondsToSelector:@selector(barChartView:colorForBarViewAtIndex:)])
+                {
+                    backgroundColor = [self.dataSource barChartView:self colorForBarViewAtIndex:index];
+                    NSAssert(backgroundColor != nil, @"JBBarChartView // datasource function - (UIColor *)barChartView:(JBBarChartView *)barChartView colorForBarViewAtIndex:(NSUInteger)index must return a non-nil UIColor");
+                }
+                else
+                {
+                    backgroundColor = kJBBarChartViewDefaultBarColor;
+                }
+
+                barView.backgroundColor = backgroundColor;
             }
+
             CGFloat height = [self normalizedHeightForRawHeight:[self.chartDataDictionary objectForKey:key]];
             CGFloat extensionHeight = height > 0.0 ? kJBBarChartViewPopOffset : 0.0;
             barView.frame = CGRectMake(xOffset, self.bounds.size.height - height - self.footerView.frame.size.height + self.headerPadding, [self barWidth], height + extensionHeight - self.headerPadding);

--- a/JBChartViewDemo/JBChartViewDemo/Controllers/JBBarChartViewController.m
+++ b/JBChartViewDemo/JBChartViewDemo/Controllers/JBBarChartViewController.m
@@ -155,11 +155,9 @@ NSString * const kJBBarChartViewControllerNavButtonViewKey = @"view";
     return kJBBarChartViewControllerBarPadding;
 }
 
-- (UIView *)barChartView:(JBBarChartView *)barChartView barViewAtIndex:(NSUInteger)index
+- (UIColor *)barChartView:(JBBarChartView *)barChartView colorForBarViewAtIndex:(NSUInteger)index
 {
-    UIView *barView = [[UIView alloc] init];
-    barView.backgroundColor = (index % 2 == 0) ? kJBColorBarChartBarBlue : kJBColorBarChartBarGreen;
-    return barView;
+    return (index % 2 == 0) ? kJBColorBarChartBarBlue : kJBColorBarChartBarGreen;
 }
 
 - (UIColor *)barSelectionColorForBarChartView:(JBBarChartView *)barChartView


### PR DESCRIPTION
Implement user-friendly method to set proper color of bar chart. 
(The same thing is already implemented for JBLineChartView lineChartLinesView:colorForLineAtLineIndex:)

Try to save great author's code style  and add documentation for this method.

Logic: Check if this method implemented and set specified color before set the default kJBBarChartViewDefaultBarColor.

Also implement this method in Example project
