### PR TITLE
barWidth selector and better height normalization

### DIFF
--- a/Classes/JBBarChartView.h
+++ b/Classes/JBBarChartView.h
@@ -44,6 +44,15 @@
 @optional
 
 /**
+ *  Width for each bar.
+ *
+ *  @param barChartView     The bar chart object requesting this information
+ *
+ *  @return The x-axis width of the supplied barChart
+ */
+- (CGFloat) barWidthForBarChart:(JBBarChartView *)barChartView;
+
+/**
  *  Occurs when a touch gesture event occurs on a given bar (chart must be expanded).
  *  and the selection must occur within the bounds of the chart.
  *

--- a/Classes/JBBarChartView.m
+++ b/Classes/JBBarChartView.m
@@ -273,6 +273,7 @@ static UIColor *kJBBarChartViewDefaultBarColor = nil;
     CGFloat minHeight = [self minimumValue];
     CGFloat maxHeight = [self maximumValue];
     CGFloat value = [rawHeight floatValue];
+    minHeight = minHeight - ((maxHeight - minHeight) / 4.0);
     
     if ((maxHeight - minHeight) <= 0)
     {
@@ -284,12 +285,19 @@ static UIColor *kJBBarChartViewDefaultBarColor = nil;
 
 - (CGFloat)barWidth
 {
-    NSUInteger barCount = [[self.chartDataDictionary allKeys] count];
-    if (barCount > 0)
+    if ([self.dataSource respondsToSelector:@selector(barWidthForBarChart:)])
     {
-        CGFloat totalPadding = (barCount - 1) * self.barPadding;
-        CGFloat availableWidth = self.bounds.size.width - totalPadding;
-        return availableWidth / barCount;
+        return [self.delegate barWidthForBarChart:self];
+    }
+    else
+    {
+        NSUInteger barCount = [[self.chartDataDictionary allKeys] count];
+        if (barCount > 0)
+        {
+            CGFloat totalPadding = (barCount - 1) * self.barPadding;
+            CGFloat availableWidth = self.bounds.size.width - totalPadding;
+            return availableWidth / barCount;
+        }
     }
     return 0;
 }


### PR DESCRIPTION
Ability to select and use a custom bar width for JBBarChartView.
Fixed the previous height normalization which left the smallest bar of the chart with 0 height (if barChartView.minimumValue wasn't manually set).
