### PR TITLE
iOS Framework Support

### DIFF
--- a/Classes/JBChartView.h
+++ b/Classes/JBChartView.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+@import UIKit;
 
 extern CGFloat const kJBChartViewDefaultAnimationDuration;
 


### PR DESCRIPTION
Added a UIKit import statement for use when JBChartView is added to a
Xcode project as a framework (iOS 8).
