### PR TITLE
Add ability for the graphs to always show the selected data value and to pre-set which index is selected

### DIFF
--- a/Classes/JBBarChartView.h
+++ b/Classes/JBBarChartView.h
@@ -127,6 +127,20 @@
  */
 @property (nonatomic, assign) BOOL showsVerticalSelection;
 
+/**
+ *  Vertical highlight overlayed on the graph at all times, not just during touch events.
+ *
+ *  Default: NO.
+ */
+@property (nonatomic, assign) BOOL alwaysShowSelection;
+
+/**
+ *  Sets the index of the initially selected data point
+ *
+ *  Default: 0.
+ */
+@property (nonatomic, assign) NSInteger selectedIndex;
+
 /*
  *  Bars can be (vertically) positoned top to bottom instead of bottom up.
  *  If this property is set to YES, both the bar and the selection view will be inverted.

--- a/Classes/JBBarChartView.m
+++ b/Classes/JBBarChartView.m
@@ -120,8 +120,6 @@ static UIColor *kJBBarChartViewDefaultBarColor = nil;
     // reset cached max height
     self.cachedMinHeight = kJBBarChartViewUndefinedCachedHeight;
     self.cachedMaxHeight = kJBBarChartViewUndefinedCachedHeight;
-
-    CGRect mainViewRect = CGRectMake(self.bounds.origin.x, self.bounds.origin.y, self.bounds.size.width, [self availableHeight]);
     
     /*
      * The data collection holds all position information:

--- a/Classes/JBBarChartView.m
+++ b/Classes/JBBarChartView.m
@@ -154,7 +154,10 @@ static UIColor *kJBBarChartViewDefaultBarColor = nil;
         else
         {
             NSUInteger totalBars = [[self.chartDataDictionary allKeys] count];
-            self.barPadding = (1/(float)totalBars) * kJBBarChartViewBarBasePaddingMutliplier;
+            self.barPadding = 0;
+            if (totalBars > 0) {
+                self.barPadding = (1/(float)totalBars) * kJBBarChartViewBarBasePaddingMutliplier;
+            }
         }
     };
     

--- a/Classes/JBLineChartView.h
+++ b/Classes/JBLineChartView.h
@@ -307,6 +307,20 @@ typedef NS_ENUM(NSInteger, JBLineChartViewLineStyle){
 @property (nonatomic, assign) BOOL showsVerticalSelection;
 
 /**
+ *  Vertical highlight overlayed on the graph at all times, not just during touch events.
+ *
+ *  Default: NO.
+ */
+@property (nonatomic, assign) BOOL alwaysShowSelection;
+
+/**
+ *  Sets the index of the initially selected data point
+ *
+ *  Default: 0.
+ */
+@property (nonatomic, assign) NSInteger selectedIndex;
+
+/**
  *  A highlight shown on a line within the graph during touch events. The highlighted line
  *  is the closest line to the touch point and corresponds to the lineIndex delegatd back via 
  *  didSelectChartAtHorizontalIndex:atLineIndex: and didUnSlectChartAtHorizontalIndex:atLineIndex:

--- a/Classes/JBLineChartView.m
+++ b/Classes/JBLineChartView.m
@@ -234,6 +234,7 @@ static UIColor *kJBLineChartViewDefaultDotSelectionColor = nil;
 - (void)construct
 {
     _showsVerticalSelection = YES;
+    _alwaysShowSelection = NO;
     _showsLineSelection = YES;
     _cachedMinHeight = kJBBarChartViewUndefinedCachedHeight;
     _cachedMaxHeight = kJBBarChartViewUndefinedCachedHeight;
@@ -382,9 +383,13 @@ static UIColor *kJBLineChartViewDefaultDotSelectionColor = nil;
             }
         }
 
-        self.verticalSelectionView = [[JBChartVerticalSelectionView alloc] initWithFrame:CGRectMake(0, 0, selectionViewWidth, verticalSelectionViewHeight)];
-        self.verticalSelectionView.alpha = 0.0;
-        self.verticalSelectionView.hidden = !self.showsVerticalSelection;
+        CGFloat xLoc = 0;
+        if (self.selectedIndex >= 0) {
+            xLoc = self.selectedIndex * mainViewRect.size.width / self.dataCount - (selectionViewWidth / 4);
+        }
+        self.verticalSelectionView = [[JBChartVerticalSelectionView alloc] initWithFrame:CGRectMake(xLoc, 0, selectionViewWidth, verticalSelectionViewHeight)];
+        self.verticalSelectionView.alpha = (self.alwaysShowSelection || self.selectedIndex >= 0) ? 1.0 : 0.0;
+        self.verticalSelectionView.hidden = (self.alwaysShowSelection || self.selectedIndex >= 0) ? NO : !self.showsVerticalSelection;
 
         // Add new selection bar
         if (self.footerView)
@@ -1006,7 +1011,7 @@ static UIColor *kJBLineChartViewDefaultDotSelectionColor = nil;
 
 - (void)setVerticalSelectionViewVisible:(BOOL)verticalSelectionViewVisible animated:(BOOL)animated
 {
-    _verticalSelectionViewVisible = verticalSelectionViewVisible;
+    _verticalSelectionViewVisible = (_alwaysShowSelection) ? YES : verticalSelectionViewVisible;
 
     if (animated)
     {
@@ -1028,7 +1033,13 @@ static UIColor *kJBLineChartViewDefaultDotSelectionColor = nil;
 - (void)setShowsVerticalSelection:(BOOL)showsVerticalSelection
 {
     _showsVerticalSelection = showsVerticalSelection;
-    self.verticalSelectionView.hidden = _showsVerticalSelection ? NO : YES;
+    self.verticalSelectionView.hidden = (_alwaysShowSelection) ? NO : !_showsVerticalSelection;
+}
+
+- (void)setAlwaysShowSelection:(BOOL)alwaysShowSelection {
+
+    _alwaysShowSelection = alwaysShowSelection;
+    self.verticalSelectionView.hidden = (_alwaysShowSelection) ? NO : !_showsVerticalSelection;
 }
 
 #pragma mark - Gestures


### PR DESCRIPTION
We found it useful for our interface to have the selection view stay visible, even when the user isn't touching the graph.  In this way, we have a summary view that always displays one data point from the graph and the selection view shows what point is being displayed.

We also liked having the graph start with a particular data point selected, in our case the maximum value.  As a result, we added a quick method call to 'setSelectedIndex' for both charts.  Because of the way the delegates work, you have to manually call 'didSelectBar/LineAtIndex' after you 'setSelectedIndex' to see it, but that isn't really that constraining.