### PR TITLE
Nil out delegate and datasource on dealloc

### DIFF
--- a/Classes/JBLineChartView.m
+++ b/Classes/JBLineChartView.m
@@ -312,6 +312,7 @@ static UIColor *kJBLineChartViewDefaultDotSelectionColor = nil;
         // Remove old line view
         if (self.linesView)
         {
+            self.linesView.delegate = nil;
             [self.linesView removeFromSuperview];
             self.linesView = nil;
         }
@@ -339,6 +340,7 @@ static UIColor *kJBLineChartViewDefaultDotSelectionColor = nil;
         // Remove old dot view
         if (self.dotsView)
         {
+            self.dotsView.delegate = nil;
             [self.dotsView removeFromSuperview];
             self.dotsView = nil;
         }

--- a/JBChartViewDemo/JBChartViewDemo/Controllers/Base/JBBaseTableViewController.m
+++ b/JBChartViewDemo/JBChartViewDemo/Controllers/Base/JBBaseTableViewController.m
@@ -28,6 +28,12 @@
     [self.view addSubview:self.tableView];
 }
 
+- (void)dealloc
+{
+    self.tableView.delegate = nil;
+    self.tableView.dataSource = nil;
+}
+
 #pragma mark - UITableViewDataSource
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/JBChartViewDemo/JBChartViewDemo/Controllers/JBAreaChartViewController.m
+++ b/JBChartViewDemo/JBChartViewDemo/Controllers/JBAreaChartViewController.m
@@ -84,6 +84,12 @@ NSString * const kJBAreaChartViewControllerNavButtonViewKey = @"view";
     return self;
 }
 
+- (void)dealloc
+{
+    _lineChartView.delegate = nil;
+    _lineChartView.dataSource = nil;
+}
+
 #pragma mark - Data
 
 - (void)initFakeData

--- a/JBChartViewDemo/JBChartViewDemo/Controllers/JBBarChartViewController.m
+++ b/JBChartViewDemo/JBChartViewDemo/Controllers/JBBarChartViewController.m
@@ -78,6 +78,12 @@ NSString * const kJBBarChartViewControllerNavButtonViewKey = @"view";
     return self;
 }
 
+- (void)dealloc
+{
+    _barChartView.delegate = nil;
+    _barChartView.dataSource = nil;
+}
+
 #pragma mark - Date
 
 - (void)initFakeData

--- a/JBChartViewDemo/JBChartViewDemo/Controllers/JBLineChartMissingPointsViewController.m
+++ b/JBChartViewDemo/JBChartViewDemo/Controllers/JBLineChartMissingPointsViewController.m
@@ -86,6 +86,12 @@ NSString * const kJBLineChartMissingPointsViewControllerNavButtonViewKey = @"vie
     return self;
 }
 
+- (void)dealloc
+{
+    _lineChartView.delegate = nil;
+    _lineChartView.dataSource = nil;
+}
+
 #pragma mark - Data
 
 - (void)initFakeData

--- a/JBChartViewDemo/JBChartViewDemo/Controllers/JBLineChartViewController.m
+++ b/JBChartViewDemo/JBChartViewDemo/Controllers/JBLineChartViewController.m
@@ -86,6 +86,12 @@ NSString * const kJBLineChartViewControllerNavButtonViewKey = @"view";
     return self;
 }
 
+- (void)dealloc
+{
+    _lineChartView.delegate = nil;
+    _lineChartView.dataSource = nil;
+}
+
 #pragma mark - Data
 
 - (void)initFakeData

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ To initialize a <i>JBBarChartView</i>, you only need a few lines of code (see be
     barChartView.dataSource = self;
     barChartView.delegate = self;
     [self addSubview:barChartView];
+
+Just like you would for a `UITableView`, ensure you clear these properties in your `dealloc`:
+
+	- (void)dealloc
+	{
+		JBBarChartView *barChartView = ...; // i.e. _barChartView
+		barChartView.delegate = nil;
+		barChartView.dataSource = nil;
+	}
     
 At a minimum, you need to inform the data source how many bars are in the chart:
 
@@ -99,9 +108,18 @@ Lastly, ensure you have set the *frame* of your barChartView & call *reloadData*
 Similiarily, to initialize a JBLineChartView, you only need a few lines of code (see below). Line charts can also be initialized via a <b>nib</b> or with a <b>frame</b>.
 
 	JBLineChartView *lineChartView = [[JBLineChartView alloc] init];
-    lineChartView.dataSource = self;
-    lineChartView.delegate = self;
-    [self addSubview:lineChartView];
+	lineChartView.dataSource = self;
+	lineChartView.delegate = self;
+	[self addSubview:lineChartView];
+
+Just like you would for a `UITableView`, ensure you clear these properties in your `dealloc`:
+
+	- (void)dealloc
+	{
+		JBLineChartView *lineChartView = ...; // i.e. _lineChartView
+		lineChartView.delegate = nil;
+		lineChartView.dataSource = nil;
+	}
 
 At a minimum, you need to inform the data source how many lines and vertical data points (for each line) are in the chart:
 


### PR DESCRIPTION
Though `weak` properties help with this, it's generally still a good idea to do it everywhere because many of the `delegate` properties in Cocoa use `assign` instead of `weak`. This PR pretty much just makes the project conform to the "just nil out the delegate" approach which should always be safe.