### PR TITLE
+ reloadEndedInBarChartView: delegate added

### DIFF
--- a/Classes/JBBarChartView.h
+++ b/Classes/JBBarChartView.h
@@ -27,6 +27,13 @@
 @optional
 
 /**
+ *  Occurs when reload ends
+ *
+ *  @param barChartView     A bar chart object informing the delegate about the new selection.
+ */
+- (void) reloadEndedInBarChartView:(JBBarChartView *)barChartView;
+
+/**
  *  A UIView subclass representing the bar at a particular index.
  *
  *  Default: solid black UIView.

--- a/Classes/JBBarChartView.m
+++ b/Classes/JBBarChartView.m
@@ -289,7 +289,12 @@ static UIColor *kJBBarChartViewDefaultBarColor = nil;
     self.footerView.frame = CGRectMake(self.bounds.origin.x, self.bounds.size.height - self.footerView.frame.size.height, self.bounds.size.width, self.footerView.frame.size.height);
 
     // Refresh state
-    [self setState:self.state animated:NO force:YES callback:nil];
+    __weak JBBarChartView *wself = self;
+    [self setState:self.state animated:NO force:YES callback:^{
+        if([wself.delegate respondsToSelector:@selector(reloadEndedInBarChartView:)]) {
+            [wself.delegate reloadEndedInBarChartView:wself];
+        }
+    }];
 }
 
 #pragma mark - View Quick Accessors


### PR DESCRIPTION
Added a delegate that allows us to have a feedback on when the reload of a chart has finished.
Might be useful for terminating load animations for example.