### PR TITLE
Return the available height instead of 0

### DIFF
--- a/Classes/JBBarChartView.m
+++ b/Classes/JBBarChartView.m
@@ -307,7 +307,7 @@ static UIColor *kJBBarChartViewDefaultBarColor = nil;
     
     if ((maxHeight - minHeight) <= 0)
     {
-        return 0;
+        return self.availableHeight;
     }
     
     return ((value - minHeight) / (maxHeight - minHeight)) * [self availableHeight];

--- a/Classes/JBLineChartView.m
+++ b/Classes/JBLineChartView.m
@@ -435,7 +435,7 @@ static UIColor *kJBLineChartViewDefaultDotSelectionColor = nil;
 
     if ((maxHeight - minHeight) <= 0)
     {
-        return 0;
+        return self.availableHeight;
     }
 
     return ((rawHeight - minHeight) / (maxHeight - minHeight)) * [self availableHeight];


### PR DESCRIPTION
As requested by you in our discussion.
Also: why it is NSNumber, I don't know It seems your BarChartView's normalizedHeightForRawHeight method uses NSNumber as argument, while the normalizedHeightForRawHeight method in the JBLineChartView does use a float as argument.