### PR TITLE
Delegate call to ignore touches on selected lines

### DIFF
--- a/Classes/JBLineChartView.h
+++ b/Classes/JBLineChartView.h
@@ -151,6 +151,13 @@ typedef NS_ENUM(NSInteger, JBLineChartViewLineStyle){
 - (void)didDeselectLineInLineChartView:(JBLineChartView *)lineChartView;
 
 /**
+ *  Returns whether the graph should ignore this line's selection when matching the line index to touch point
+ *
+ *  @param lineIndex        An index number identifying the closest line in the chart to the current touch
+ */
+- (BOOL)lineChartView:(JBLineChartView *)lineChartView shouldIgnoreSelectionAtIndex:(NSUInteger)lineIndex;
+
+/**
  *  Returns the color of particular line at lineIndex within the chart.
  *
  *  Default: black color.

--- a/Classes/JBLineChartView.m
+++ b/Classes/JBLineChartView.m
@@ -952,6 +952,15 @@ static UIColor *kJBLineChartViewDefaultDotSelectionColor = nil;
     for (NSUInteger lineIndex=0; lineIndex<numberOfLines; lineIndex++)
     {
         NSAssert([self.dataSource respondsToSelector:@selector(lineChartView:numberOfVerticalValuesAtLineIndex:)], @"JBLineChartView // dataSource must implement - (NSUInteger)lineChartView:(JBLineChartView *)lineChartView numberOfVerticalValuesAtLineIndex:(NSUInteger)lineIndex");
+        
+        if ([self.delegate respondsToSelector:@selector(lineChartView:shouldIgnoreSelectionAtIndex:)])
+        {
+            if([self.delegate lineChartView:self shouldIgnoreSelectionAtIndex:lineIndex])
+            {
+                continue;
+            }
+        }
+        
         if ([self.dataSource lineChartView:self numberOfVerticalValuesAtLineIndex:lineIndex] > rightHorizontalIndex)
         {
             NSArray *lineData = [self.chartData objectAtIndex:lineIndex];


### PR DESCRIPTION
If you want to display more lines than are touchable, you can ignore certain indices.  Specifically, we currently use this when plotting lines above and below an axis, where we might not want the axis to respond to touch.