### PR TITLE
Make sure to import dependent framework header explicitly

### DIFF
--- a/Classes/Bar/Views/JBGradientBarView.h
+++ b/Classes/Bar/Views/JBGradientBarView.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @class JBGradientBarView;
 

--- a/Classes/Line/Layers/JBGradientLineLayer.h
+++ b/Classes/Line/Layers/JBGradientLineLayer.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface JBGradientLineLayer : CAGradientLayer
 

--- a/Classes/Line/Models/JBLineChartPoint.h
+++ b/Classes/Line/Models/JBLineChartPoint.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 @interface JBLineChartPoint : NSObject
 

--- a/Classes/Line/Views/JBLineChartDotView.h
+++ b/Classes/Line/Views/JBLineChartDotView.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface JBLineChartDotView : UIView
 

--- a/Classes/Line/Views/JBLineChartDotsView.h
+++ b/Classes/Line/Views/JBLineChartDotsView.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 // Numerics
 extern NSInteger const kJBLineChartDotsViewUnselectedLineIndex;

--- a/Classes/Line/Views/JBLineChartLinesView.h
+++ b/Classes/Line/Views/JBLineChartLinesView.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 // Numerics
 extern NSInteger const kJBLineChartLinesViewUnselectedLineIndex;


### PR DESCRIPTION
I forked JBChartView to create embedded framework at [here](https://github.com/yasuoza/JBChartView).
As of JBChartView >= 3.0.0, there is compile errors like

```
In file included from JBChartView/Classes/Bar/Views/JBGradientBarView.m:9:
JBChartView/Classes/Bar/Views/JBGradientBarView.h:19:4: error: expected a type

- (CGRect)chartViewBoundsForGradientBarView:(JBGradientBarView *)gradientBarView;
JBChartView/Classes/Bar/Views/JBGradientBarView.h:23:31: error: cannot find interface declaration for 'UIView', superclass of 'JBGradientBarView'

@interface JBGradientBarView: UIView
~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ^
JBChartView/Classes/Bar/Views/JBGradientBarView.h:26:31: error: unknown type name 'CAGradientLayer'
```

This pull request solves above errors.

**_Note_**
For this pull request, I referred to JBChartView.h which already imports `<UIKit/UIKit.h>`
https://github.com/Jawbone/JBChartView/blob/master/Classes/Base/JBChartView.h#L10