### PR TITLE
Add missing `-lineChartView:selectionColorStyleForLineAtLineIndex:` JBLineChartViewDelegate method.

### DIFF
--- a/Classes/Bar/JBBarChartView.m
+++ b/Classes/Bar/JBBarChartView.m
@@ -10,6 +10,7 @@
 
 // Views
 #import "JBGradientBarView.h"
+#import "JBChartVerticalSelectionView.h"
 
 // Numerics
 static CGFloat const kJBBarChartViewBarBasePaddingMutliplier = 50.0f;

--- a/Classes/Base/JBChartView.h
+++ b/Classes/Base/JBChartView.h
@@ -152,19 +152,3 @@ typedef NS_ENUM(NSInteger, JBChartViewState){
 - (void)setState:(JBChartViewState)state animated:(BOOL)animated;
 
 @end
-
-/**
- * A simple UIView subclass that fades a base color from current alpha to 0.0 (vertically).
- * Used as a vertical selection view in JBChartView subclasses.
- */
-@interface JBChartVerticalSelectionView : UIView
-
-/**
- * Base selection view color. This color will be faded to transparent vertically.
- *
- * Default: white color.
- *
- */
-@property (nonatomic, strong) UIColor *bgColor;
-
-@end

--- a/Classes/Base/JBChartView.m
+++ b/Classes/Base/JBChartView.m
@@ -11,9 +11,6 @@
 // Numerics
 CGFloat const kJBChartViewDefaultAnimationDuration = 0.25f;
 
-// Color (JBChartSelectionView)
-static UIColor *kJBChartVerticalSelectionViewDefaultBgColor = nil;
-
 @interface JBChartView ()
 
 @property (nonatomic, assign) BOOL hasMaximumValue;
@@ -160,76 +157,6 @@ static UIColor *kJBChartVerticalSelectionViewDefaultBgColor = nil;
 - (void)resetMaximumValue
 {
 	_hasMaximumValue = NO; // clears max
-}
-
-@end
-
-@implementation JBChartVerticalSelectionView
-
-#pragma mark - Alloc/Init
-
-+ (void)initialize
-{
-	if (self == [JBChartVerticalSelectionView class])
-	{
-		kJBChartVerticalSelectionViewDefaultBgColor = [UIColor whiteColor];
-	}
-}
-
-- (id)initWithFrame:(CGRect)frame
-{
-	self = [super initWithFrame:frame];
-	if (self)
-	{
-		self.backgroundColor = [UIColor clearColor];
-	}
-	return self;
-}
-
-#pragma mark - Drawing
-
-- (void)drawRect:(CGRect)rect
-{
-	CGContextRef context = UIGraphicsGetCurrentContext();
-	[[UIColor clearColor] set];
-	CGContextFillRect(context, rect);
-	
-	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-	CGFloat locations[] = { 0.0, 1.0 };
-	
-	NSArray *colors = nil;
-	if (self.bgColor != nil)
-	{
-		colors = @[(__bridge id)self.bgColor.CGColor, (__bridge id)[self.bgColor colorWithAlphaComponent:0.0].CGColor];
-	}
-	else
-	{
-		colors = @[(__bridge id)kJBChartVerticalSelectionViewDefaultBgColor.CGColor, (__bridge id)[kJBChartVerticalSelectionViewDefaultBgColor colorWithAlphaComponent:0.0].CGColor];
-	}
-	
-	CGGradientRef gradient = CGGradientCreateWithColors(colorSpace, (__bridge CFArrayRef) colors, locations);
-	
-	CGPoint startPoint = CGPointMake(CGRectGetMidX(rect), CGRectGetMaxY(rect));
-	CGPoint endPoint = CGPointMake(CGRectGetMidX(rect), CGRectGetMinY(rect));
-	
-	CGContextSaveGState(context);
-	{
-		CGContextAddRect(context, rect);
-		CGContextClip(context);
-		CGContextDrawLinearGradient(context, gradient, startPoint, endPoint, 0);
-	}
-	CGContextRestoreGState(context);
-	
-	CGGradientRelease(gradient);
-	CGColorSpaceRelease(colorSpace);
-}
-
-#pragma mark - Setters
-
-- (void)setBgColor:(UIColor *)bgColor
-{
-	_bgColor = bgColor;
-	[self setNeedsDisplay];
 }
 
 @end

--- a/Classes/Line/JBLineChartView.h
+++ b/Classes/Line/JBLineChartView.h
@@ -330,7 +330,6 @@ typedef NS_ENUM(NSInteger, JBLineChartViewColorStyle) {
 /**
  *  Returns the selection color of a line within the chart during touch events.
  *  The property showsLineSelection must be YES for the color to apply.
- *  As well, lineChartView:selectionColorStyleForLineAtLineIndex: must return JBLineChartViewColorStyleSolid (default).
  *
  *  Default: matches lineChartView:colorForLineAtLineIndex:.
  *
@@ -340,6 +339,19 @@ typedef NS_ENUM(NSInteger, JBLineChartViewColorStyle) {
  *  @return The color to be used to highlight a line during chart selections.
  */
 - (UIColor *)lineChartView:(JBLineChartView *)lineChartView selectionColorForLineAtLineIndex:(NSUInteger)lineIndex;
+
+/**
+ *  Returns the selection style of a line within the chart during touch events.
+ *  The property showsLineSelection must be YES for the style to apply.
+ *
+ *  Default: Gradient
+ *
+ *  @param lineChartView    The line chart object requesting this information.
+ *  @param lineIndex        An index number identifying a line in the chart.
+ *
+ *  @return The style to be used to highlight a line during chart selections.
+ */
+- (JBLineChartViewColorStyle)lineChartView:(JBLineChartView *)lineChartView selectionColorStyleForLineAtLineIndex:(NSUInteger)lineIndex;
 
 /**
  *  Returns the selection gradient layer of a line within the chart during touch events.

--- a/Classes/Line/JBLineChartView.m
+++ b/Classes/Line/JBLineChartView.m
@@ -15,6 +15,7 @@
 // Views
 #import "JBLineChartDotsView.h"
 #import "JBLineChartLinesView.h"
+#import "JBChartVerticalSelectionView.h"
 
 // Enums
 typedef NS_ENUM(NSUInteger, JBLineChartHorizontalIndexClamp){
@@ -1089,6 +1090,15 @@ static NSInteger const kJBLineChartUnselectedLineIndex = -1;
 		NSAssert(verticalSelectionColor != nil, @"JBLineChartView // delegate function - (UIColor *)lineChartView:(JBLineChartView *)lineChartView verticalSelectionColorForLineAtLineIndex:(NSUInteger)lineIndex must return a non-nil UIColor");
 		self.verticalSelectionView.bgColor = verticalSelectionColor;
 	}
+
+    if ([self.delegate respondsToSelector:@selector(lineChartView:selectionColorStyleForLineAtLineIndex:)])
+    {
+        JBLineChartViewColorStyle selectionColorStyle = [self.delegate lineChartView:self selectionColorStyleForLineAtLineIndex:lineIndex];
+        self.verticalSelectionView.style = selectionColorStyle;
+    }
+    else {
+        self.verticalSelectionView.style = JBLineChartViewColorStyleGradient;
+    }
 	
 	CGFloat xOffset = fmin(self.bounds.size.width - self.verticalSelectionView.frame.size.width, fmax(0, touchPoint.x - (self.verticalSelectionView.frame.size.width * 0.5)));
 	CGFloat yOffset = self.headerView.frame.size.height + self.headerPadding;

--- a/Classes/Line/Views/JBChartVerticalSelectionView.h
+++ b/Classes/Line/Views/JBChartVerticalSelectionView.h
@@ -1,0 +1,34 @@
+//
+//  JBChartVerticalSelectionView.h
+//  JBChartView
+//
+//  Created by Javier Soto on 4/27/16.
+//
+//
+
+#import <UIKit/UIKit.h>
+#import "JBLineChartView.h"
+
+/**
+ * A simple UIView subclass that fades a base color from current alpha to 0.0 (vertically).
+ * Used as a vertical selection view in JBChartView subclasses.
+ */
+@interface JBChartVerticalSelectionView : UIView
+
+/**
+ * Base selection view color. This color will be drawn according to self.style.
+ *
+ * Default: white color.
+ *
+ */
+@property (nonatomic, strong) UIColor *bgColor;
+
+/**
+ * How bgColor will be drawn in the view.
+ *
+ * Default: JBLineChartViewColorStyleGradient.
+ *
+ */
+@property (nonatomic) JBLineChartViewColorStyle style;
+
+@end

--- a/Classes/Line/Views/JBChartVerticalSelectionView.m
+++ b/Classes/Line/Views/JBChartVerticalSelectionView.m
@@ -1,0 +1,106 @@
+//
+//  JBChartVerticalSelectionView.m
+//  JBChartView
+//
+//  Created by Javier Soto on 4/27/16.
+//
+//
+
+#import "JBChartVerticalSelectionView.h"
+
+static UIColor *kJBChartVerticalSelectionViewDefaultBgColor = nil;
+
+@implementation JBChartVerticalSelectionView
+
+@synthesize bgColor = _bgColor;
+
+#pragma mark - Alloc/Init
+
++ (void)initialize
+{
+    if (self == [JBChartVerticalSelectionView class])
+    {
+        kJBChartVerticalSelectionViewDefaultBgColor = [UIColor whiteColor];
+    }
+}
+
+- (id)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self)
+    {
+        self.backgroundColor = [UIColor clearColor];
+        self.style = JBLineChartViewColorStyleGradient;
+    }
+    return self;
+}
+
+#pragma mark - Drawing
+
+- (void)drawRect:(CGRect)rect
+{
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    [[UIColor clearColor] set];
+    CGContextFillRect(context, rect);
+
+    switch (self.style) {
+        case JBLineChartViewColorStyleGradient:
+        {
+            CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+            CGFloat locations[] = { 0.0, 1.0 };
+
+            NSArray *colors = @[(__bridge id)self.bgColor.CGColor, (__bridge id)[self.bgColor colorWithAlphaComponent:0.0].CGColor];
+
+            CGGradientRef gradient = CGGradientCreateWithColors(colorSpace, (__bridge CFArrayRef) colors, locations);
+
+            CGPoint startPoint = CGPointMake(CGRectGetMidX(rect), CGRectGetMaxY(rect));
+            CGPoint endPoint = CGPointMake(CGRectGetMidX(rect), CGRectGetMinY(rect));
+
+            CGContextSaveGState(context);
+            {
+                CGContextAddRect(context, rect);
+                CGContextClip(context);
+                CGContextDrawLinearGradient(context, gradient, startPoint, endPoint, 0);
+            }
+            CGContextRestoreGState(context);
+
+            CGGradientRelease(gradient);
+            CGColorSpaceRelease(colorSpace);
+
+            break;
+        }
+
+        case JBLineChartViewColorStyleSolid:
+            [self.bgColor set];
+            CGContextFillRect(context, rect);
+            break;
+
+        default:
+            NSAssert(false, @"Invalid JBLineChartViewColorStyle value: %@", @(self.style));
+    }
+}
+
+#pragma mark - Setters
+
+- (UIColor *)bgColor
+{
+    return _bgColor ?: kJBChartVerticalSelectionViewDefaultBgColor;
+}
+
+- (void)setBgColor:(UIColor *)bgColor
+{
+    if (bgColor != _bgColor) {
+        _bgColor = bgColor;
+        [self setNeedsDisplay];
+    }
+}
+
+-(void)setStyle:(JBLineChartViewColorStyle)style
+{
+    if (style != _style) {
+        _style = style;
+        [self setNeedsDisplay];
+    }
+}
+
+@end


### PR DESCRIPTION
It was referenced in the documentation, but never actually used.
This change is not an API-breaking change. The default remains to render the line using a gradient.
This adds the ability to render the selection line using a solid a line without a gradient.